### PR TITLE
feat: replace email with phone in Person model and update related logic

### DIFF
--- a/prisma/migrations/20250609212616_replace_email_with_phone/migration.sql
+++ b/prisma/migrations/20250609212616_replace_email_with_phone/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `email` on the `Person` table. All the data in the column will be lost.
+  - Added the required column `phone` to the `Person` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Person" DROP COLUMN "email",
+ADD COLUMN     "phone" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ datasource db {
 model Person {
   id            Int         @id @default(autoincrement())
   name          String
-  email         String
+  phone         String
   isGoEvent     Boolean
   countChildren Int
   companions    Companion[]

--- a/src/api/controller/form-controler.ts
+++ b/src/api/controller/form-controler.ts
@@ -9,7 +9,7 @@ type isGoToEventType = "1" | "0";
 
 interface WeddingParams {
   isGoToEvent: isGoToEventType;
-  email: string;
+  phone: string;
   name: string;
   adultCount: number;
   childCount: number;
@@ -17,16 +17,16 @@ interface WeddingParams {
 }
 
 export async function respondToWeddingInvite(body: WeddingParams) {
-  const validateEmail = await prisma.person.findFirst({
+  const validatephone = await prisma.person.findFirst({
     where: {
-      email: body.email,
+      phone: body.phone,
     },
   });
 
-  if (validateEmail) {
+  if (validatephone) {
     return {
-      message: "Este email já foi utilizado para responder ao formulário.",
-      data: validateEmail,
+      message: "Este telefone já foi utilizado para responder ao formulário.",
+      data: validatephone,
       status: 400,
     };
   }
@@ -36,7 +36,7 @@ export async function respondToWeddingInvite(body: WeddingParams) {
     person = await prisma.person.create({
       data: {
         name: body.name,
-        email: body.email,
+        phone: body.phone,
         isGoEvent: body.isGoToEvent === "1",
         countChildren: body.childCount,
       },

--- a/src/api/routes/form-route.ts
+++ b/src/api/routes/form-route.ts
@@ -9,7 +9,7 @@ export const subscribeToEventRoute: FastifyPluginAsyncZod = async (app) => {
       schema: {
         body: z.object({
           isGoToEvent: z.enum(["1", "0"]),
-          email: z.string().min(1).email(),
+          phone: z.string().min(1),
           name: z.string().min(1),
           adultCount: z.number(),
           childCount: z.number(),


### PR DESCRIPTION
This pull request replaces the use of `email` with `phone` throughout the application, including database schema changes, API updates, and validation logic.

### Database Schema Changes:
* In `prisma/migrations/20250609212616_replace_email_with_phone/migration.sql`, the `email` column was dropped from the `Person` table, and a new required `phone` column was added without a default value.
* In `prisma/schema.prisma`, the `email` field in the `Person` model was replaced with a `phone` field.

### API Updates:
* In `src/api/controller/form-controler.ts`, all references to `email` were replaced with `phone` in the `WeddingParams` interface, database queries, and error messages. For example, the `validateEmail` variable was renamed to `validatephone`, and the error message was updated to reflect the change. [[1]](diffhunk://#diff-b99091805c7d85c4b663db613d8b1c4d13065b546587a86240b26bd167eeee63L12-R29) [[2]](diffhunk://#diff-b99091805c7d85c4b663db613d8b1c4d13065b546587a86240b26bd167eeee63L39-R39)
* In `src/api/routes/form-route.ts`, the validation schema for the `subscribeToEventRoute` was updated to validate `phone` instead of `email`. The `phone` field now requires a non-empty string but no longer enforces email format validation.