### PR TITLE
feat: add ping route and update Prisma client initialization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL=
+NODE_ENV=development

--- a/src/api/routes/ping.ts
+++ b/src/api/routes/ping.ts
@@ -1,0 +1,14 @@
+import { FastifyInstance } from 'fastify'
+import { prisma } from '../../lib'
+
+export async function pingRoute(app: FastifyInstance) {
+  app.get('/ping', async (request, reply) => {
+    try {
+      await prisma.person.findFirst({ select: { id: true } })
+      return reply.send({ ok: true })
+    } catch (err) {
+      console.error('Erro no ping:', err)
+      return reply.status(500).send({ ok: false, error: 'Erro no ping' })
+    }
+  })
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -7,6 +7,7 @@ import {
 } from "fastify-type-provider-zod";
 
 import { subscribeToEventRoute } from "./routes/form-route";
+import { pingRoute } from "./routes/ping";
 
 const app = fastify().withTypeProvider<ZodTypeProvider>();
 app.setSerializerCompiler(serializerCompiler);
@@ -14,7 +15,7 @@ app.setValidatorCompiler(validatorCompiler);
 app.register(fastifyCors);
 
 app.register(subscribeToEventRoute);
-
+app.register(pingRoute);
 
 app.get("/is-alive", async () => {
   return { message: "ok" };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,9 @@
 import { PrismaClient } from "@prisma/client";
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
-export const prisma = new PrismaClient({
-  log: ["query"],
+
+export const prisma = globalForPrisma.prisma || new PrismaClient({
+  log: ["query", "info", "warn", "error"],
 });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,7 +3,7 @@ const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
 
 export const prisma = globalForPrisma.prisma || new PrismaClient({
-  log: ["query", "info", "warn", "error"],
+  log: process.env.NODE_ENV !== "production" ? ["query", "info", "warn", "error"] : ["info", "warn", "error"],
 });
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
This pull request introduces a new `/ping` route to the API, improves the Prisma client initialization, and adds a new environment variable to the `.env.example` file. The changes enhance the application's functionality and ensure better handling of the Prisma client in development and production environments.

### New `/ping` route:
* [`src/api/routes/ping.ts`](diffhunk://#diff-8dccd85272bc22790fe70742ecaf43b5153addc98e94e6e190b83e40c57b758fR1-R14): Added a new `pingRoute` function to handle `/ping` requests, which checks database connectivity using Prisma and returns a success or error response.
* [`src/api/server.ts`](diffhunk://#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8R10-R18): Registered the new `pingRoute` in the Fastify server setup.

### Prisma client improvements:
* [`src/lib/index.ts`](diffhunk://#diff-df0a988f9e523993e537dd35bfb5768e6d1cc02349e28cceaa2e2be205433433R2-R9): Updated the Prisma client initialization to reuse the client in development mode and added more detailed logging levels (`query`, `info`, `warn`, `error`).

### Environment variable addition:
* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR2): Added `NODE_ENV=development` to provide a default environment variable for development mode.