### PR TITLE
feat: add ping database route and integrate with server

### DIFF
--- a/src/api/routes/ping-db.ts
+++ b/src/api/routes/ping-db.ts
@@ -1,0 +1,14 @@
+import { FastifyInstance } from 'fastify'
+import { prisma } from '../../lib'
+
+export async function pingRouteDB(app: FastifyInstance) {
+  app.get('/pingdb', async (request, reply) => {
+    try {
+      await prisma.person.findFirst({ select: { id: true } })
+      return reply.send({ ok: true })
+    } catch (err) {
+      console.error('Erro no ping:', err)
+      return reply.status(500).send({ ok: false, error: 'Erro no ping' })
+    }
+  })
+}

--- a/src/api/routes/ping.ts
+++ b/src/api/routes/ping.ts
@@ -1,11 +1,9 @@
 import { FastifyInstance } from 'fastify'
-import { prisma } from '../../lib'
 
 export async function pingRoute(app: FastifyInstance) {
   app.get('/ping', async (request, reply) => {
     try {
-      await prisma.person.findFirst({ select: { id: true } })
-      return reply.send({ ok: true })
+      return reply.send({ ok: true, timestamp: new Date().toISOString() })
     } catch (err) {
       console.error('Erro no ping:', err)
       return reply.status(500).send({ ok: false, error: 'Erro no ping' })

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -8,6 +8,7 @@ import {
 
 import { subscribeToEventRoute } from "./routes/form-route";
 import { pingRoute } from "./routes/ping";
+import { pingRouteDB } from "./routes/ping-db";
 
 const app = fastify().withTypeProvider<ZodTypeProvider>();
 app.setSerializerCompiler(serializerCompiler);
@@ -16,6 +17,7 @@ app.register(fastifyCors);
 
 app.register(subscribeToEventRoute);
 app.register(pingRoute);
+app.register(pingRouteDB);
 
 app.get("/is-alive", async () => {
   return { message: "ok" };


### PR DESCRIPTION
This pull request introduces a new `/pingdb` route to check database connectivity and refactors the existing `/ping` route to include a timestamp in its response. It also updates the server setup to register the new route.

### New `/pingdb` Route:

* Added `pingRouteDB` in `src/api/routes/ping-db.ts` to provide a database connectivity health check. The route queries the database and returns a success or error response based on the database connection status.
* Registered the `pingRouteDB` route in `src/api/server.ts` by importing it and adding it to the Fastify instance. [[1]](diffhunk://#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8R11) [[2]](diffhunk://#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8R20)

### Refactor of `/ping` Route:

* Updated the `/ping` route in `src/api/routes/ping.ts` to remove the database query and instead return a response with a timestamp, simplifying the endpoint's purpose.